### PR TITLE
Fix: Table glpi_assets_assets cannot be renamed as table...

### DIFF
--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -846,7 +846,7 @@ class PluginGenericobjectType extends CommonDBTM
         /** @var DBmysql $DB */
         global $DB;
 
-        if ($old_itemtype != $new_itemtype) {
+        if ($old_itemtype != $new_itemtype && !str_starts_with($old_itemtype, 'Glpi\\CustomAsset\\')) {
             $migration->renameItemtype($old_itemtype, $new_itemtype);
             $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !40808

Avoid this type of error when installing the plugin before migrating it to the core:
```
> bin/console plugin:install genericobject
Traitement du plugin « genericobject »...

In Migration.php line 1568:
                                                                                                                  
  Table "glpi_assets_assets" cannot be renamed as table "glpi_plugin_genericobject_liensoranges" already exists.  
                                                                                                                  

plugin:install [-a|--all] [-p|--param [PARAM]] [-u|--username USERNAME] [-f|--force] [--] [<directory>...]
```

## Screenshots (if appropriate):

