### PR TITLE
feat(migration): add type renaming to resolve native asset name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+- Add type renaming
+
 ## [3.0.2 End-of-Life Updater] - 2025-11-20
 
 - Secured, fixed, and enhanced the uninstall process

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/front/migration_status.php
+++ b/front/migration_status.php
@@ -34,14 +34,23 @@ use Glpi\Asset\AssetDefinition;
 // Check if user has admin rights
 Session::checkRight('config', UPDATE);
 
+/** @var array $CFG_GLPI */
 /** @var DBmysql $DB */
-global $DB;
+global $CFG_GLPI, $DB;
+
+// Handle rename POST action
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['type_id'], $_POST['new_name'])) {
+    $type_id  = (int) $_POST['type_id'];
+    $new_name = (string) $_POST['new_name'];
+    PluginGenericobjectType::renameType($type_id, $new_name);
+    Html::redirect($CFG_GLPI['root_doc'] . '/plugins/genericobject/front/migration_status.php');
+}
 
 // Get all GenericObject types
 $genericobject_types = [];
 if ($DB->tableExists(PluginGenericobjectType::getTable())) {
     $query = [
-        'SELECT' => ['itemtype', 'name'],
+        'SELECT' => ['id', 'name'],
         'FROM'   => PluginGenericobjectType::getTable(),
     ];
     $request = $DB->request($query);
@@ -72,6 +81,7 @@ Html::header(__s('GenericObject Migration Status', 'genericobject'), '', "tools"
 TemplateRenderer::getInstance()->display('@genericobject/migration_status.html.twig', [
     'genericobject_types' => $genericobject_types,
     'customassets'        => $customassets,
+    'reserved_names'      => array_map('strtolower', PluginGenericobjectType::getReservedNames()),
 ]);
 
 // Display GLPI footer

--- a/front/migration_status.php
+++ b/front/migration_status.php
@@ -79,9 +79,9 @@ Html::header(__s('GenericObject Migration Status', 'genericobject'), '', "tools"
 
 // Render the template content
 TemplateRenderer::getInstance()->display('@genericobject/migration_status.html.twig', [
-    'genericobject_types' => $genericobject_types,
-    'customassets'        => $customassets,
-    'reserved_names'      => array_map('strtolower', PluginGenericobjectType::getReservedNames()),
+    'genericobject_types'  => $genericobject_types,
+    'customassets'         => $customassets,
+    'reserved_names'       => array_map('strtolower', PluginGenericobjectType::getReservedNames()),
 ]);
 
 // Display GLPI footer

--- a/front/migration_status.php
+++ b/front/migration_status.php
@@ -38,6 +38,13 @@ Session::checkRight('config', UPDATE);
 /** @var DBmysql $DB */
 global $CFG_GLPI, $DB;
 
+// Handle get_system_name AJAX action
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['action']) && $_GET['action'] === 'get_system_name') {
+    header('Content-Type: application/json');
+    echo json_encode(['system_name' => PluginGenericobjectType::getSystemName((string) ($_GET['name'] ?? ''))]);
+    exit;
+}
+
 // Handle rename POST action
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['type_id'], $_POST['new_name'])) {
     $type_id  = (int) $_POST['type_id'];

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -857,6 +857,8 @@ class PluginGenericobjectType extends CommonDBTM
                 );
             }
         }
+
+        self::applyPluginsRename($migration, $old_itemtype, $new_itemtype);
     }
 
     /**
@@ -1120,6 +1122,48 @@ class PluginGenericobjectType extends CommonDBTM
                     ['name' => PluginGenericobjectProfile::getProfileNameForItemtype($new_itemtype)],
                     ['name' => PluginGenericobjectProfile::getProfileNameForItemtype($old_itemtype)],
                 ),
+            );
+        }
+    }
+
+    /**
+     * Update all plugin data when a genericobject type is renamed.
+     *
+     * @param Migration $migration
+     * @param string    $old_itemtype  Old itemtype class name
+     * @param string    $new_itemtype  New itemtype class name
+     */
+    private static function applyPluginsRename(
+        Migration $migration,
+        string $old_itemtype,
+        string $new_itemtype,
+    ): void {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $columns = $DB->request([
+            'SELECT' => ['TABLE_NAME'],
+            'FROM'   => 'information_schema.COLUMNS',
+            'WHERE'  => [
+                'TABLE_SCHEMA' => $DB->dbdefault,
+                'TABLE_NAME'   => ['LIKE', 'glpi\_plugin\_%'],
+                'COLUMN_NAME'  => 'itemtypes',
+            ],
+        ]);
+
+        foreach ($columns as $row) {
+            $DB->update(
+                $row['TABLE_NAME'],
+                [
+                    'itemtypes' => new QueryExpression(
+                        'REPLACE('
+                        . $DB->quoteName('itemtypes')
+                        . ', ' . $DB->quoteValue(json_encode($old_itemtype))
+                        . ', ' . $DB->quoteValue(json_encode($new_itemtype))
+                        . ')',
+                    ),
+                ],
+                ['itemtypes' => ['LIKE', '%' . $old_itemtype . '%']],
             );
         }
     }

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -749,80 +749,224 @@ class PluginGenericobjectType extends CommonDBTM
                 continue;
             }
 
-            self::updateNameAndItemtype(
+            self::applyTypeRename(
                 $migration,
+                $type['id'],
                 $old_name,
                 $new_name,
                 $old_itemtype,
                 $new_itemtype,
             );
-
-            $DB->update(
-                self::getTable(),
-                [
-                    'name'     => $new_name,
-                    'itemtype' => $new_itemtype,
-                ],
-                ['id' => $type['id']],
-            );
-
-            $DB->update(
-                self::getTable(),
-                [
-                    'linked_itemtypes' => new QueryExpression(
-                        'REPLACE('
-                        . $DB->quoteName('linked_itemtypes')
-                        . ','
-                        . $DB->quoteValue('"' . $old_itemtype . '"') // itemtype is surrounded by quotes
-                        . ','
-                        . $DB->quoteValue('"' . $new_itemtype . '"') // itemtype is surrounded by quotes
-                        . ')',
-                    ),
-                ],
-                ['linked_itemtypes' => ['LIKE', '%"' . $old_itemtype . '"%']],
-            );
-
-            // Handle dropdowns related to itemtype
-            $table  = getTableForItemType($new_itemtype);
-            $fields = $DB->listFields($table);
-            foreach ($fields as $field => $options) {
-                if (preg_match("/s_id$/", $field)) {
-                    $dropdown_old_table    = getTableNameForForeignKeyField($field);
-
-                    if (!preg_match('/^glpi_plugin_genericobject_/', $dropdown_old_table)) {
-                        continue;
-                    }
-
-                    $dropdown_old_name     = getSingular(
-                        str_replace(
-                            "glpi_plugin_genericobject_",
-                            "",
-                            $dropdown_old_table,
-                        ),
-                    );
-                    $dropdown_old_itemtype = 'PluginGenericobject' . ucfirst($dropdown_old_name);
-                    $dropdown_new_name     = self::filterInput($dropdown_old_name);
-                    $dropdown_new_itemtype = self::getClassByName($dropdown_new_name);
-
-                    if (
-                        $dropdown_old_name == $dropdown_new_name
-                        && $dropdown_old_itemtype == $dropdown_new_itemtype
-                    ) {
-                        continue;
-                    }
-
-                    self::updateNameAndItemtype(
-                        $migration,
-                        $dropdown_old_name,
-                        $dropdown_new_name,
-                        $dropdown_old_itemtype,
-                        $dropdown_new_itemtype,
-                    );
-                }
-            }
         }
 
-        ProfileRight::cleanAllPossibleRights(); // Clean all possible rights are their name may have change
+        ProfileRight::cleanAllPossibleRights();
+    }
+
+    /**
+     * Apply a full rename for a single type: update files, database tables,
+     * foreign keys, relation tables, linked_itemtypes, and related dropdowns.
+     *
+     * @param Migration $migration
+     * @param int       $type_id       ID of the type in glpi_plugin_genericobject_types
+     * @param string    $old_name      Current type name
+     * @param string    $new_name      New type name
+     * @param string    $old_itemtype  Current itemtype class name
+     * @param string    $new_itemtype  New itemtype class name
+     */
+    private static function applyTypeRename(
+        Migration $migration,
+        int $type_id,
+        string $old_name,
+        string $new_name,
+        string $old_itemtype,
+        string $new_itemtype,
+    ): void {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        self::updateNameAndItemtype(
+            $migration,
+            $old_name,
+            $new_name,
+            $old_itemtype,
+            $new_itemtype,
+        );
+
+        $DB->update(
+            self::getTable(),
+            [
+                'name'     => $new_name,
+                'itemtype' => $new_itemtype,
+            ],
+            ['id' => $type_id],
+        );
+
+        $DB->update(
+            self::getTable(),
+            [
+                'linked_itemtypes' => new QueryExpression(
+                    'REPLACE('
+                    . $DB->quoteName('linked_itemtypes')
+                    . ','
+                    . $DB->quoteValue('"' . $old_itemtype . '"') // itemtype is surrounded by quotes
+                    . ','
+                    . $DB->quoteValue('"' . $new_itemtype . '"') // itemtype is surrounded by quotes
+                    . ')',
+                ),
+            ],
+            ['linked_itemtypes' => ['LIKE', '%"' . $old_itemtype . '"%']],
+        );
+
+        // Handle dropdowns related to itemtype
+        $table  = getTableForItemType($new_itemtype);
+        $fields = $DB->listFields($table);
+        foreach ($fields as $field => $options) {
+            if (preg_match("/s_id$/", $field)) {
+                $dropdown_old_table    = getTableNameForForeignKeyField($field);
+
+                if (!preg_match('/^glpi_plugin_genericobject_/', $dropdown_old_table)) {
+                    continue;
+                }
+
+                $dropdown_old_name     = getSingular(
+                    str_replace(
+                        "glpi_plugin_genericobject_",
+                        "",
+                        $dropdown_old_table,
+                    ),
+                );
+                $dropdown_old_itemtype = 'PluginGenericobject' . ucfirst($dropdown_old_name);
+                $dropdown_new_name     = self::filterInput($dropdown_old_name);
+                $dropdown_new_itemtype = self::getClassByName($dropdown_new_name);
+
+                if (
+                    $dropdown_old_name == $dropdown_new_name
+                    && $dropdown_old_itemtype == $dropdown_new_itemtype
+                ) {
+                    continue;
+                }
+
+                self::updateNameAndItemtype(
+                    $migration,
+                    $dropdown_old_name,
+                    $dropdown_new_name,
+                    $dropdown_old_itemtype,
+                    $dropdown_new_itemtype,
+                );
+            }
+        }
+    }
+
+    /**
+     * Rename a genericobject type.
+     *
+     * Updates the type name, itemtype, all generated files, database tables,
+     * foreign keys, and all relation tables where the itemtype is referenced.
+     *
+     * @param int    $type_id  ID of the type in glpi_plugin_genericobject_types
+     * @param string $new_name New name for the type (will be filtered)
+     *
+     * @return bool True on success, false on failure
+     */
+    public static function renameType(int $type_id, string $new_name): bool
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $type = new self();
+        if (!$type->getFromDB($type_id)) {
+            Session::addMessageAfterRedirect(
+                __s('Type not found.', 'genericobject'),
+                false,
+                ERROR,
+            );
+            return false;
+        }
+
+        $old_name = $type->fields['name'];
+        $new_name = self::filterInput($new_name);
+
+        if ($new_name === '') {
+            Session::addMessageAfterRedirect(
+                __s('The new name cannot be empty.', 'genericobject'),
+                false,
+                ERROR,
+            );
+            return false;
+        }
+
+        if ($new_name === $old_name) {
+            return true;
+        }
+
+        $existing = $DB->request([
+            'FROM'  => self::getTable(),
+            'WHERE' => [
+                'name' => $new_name,
+                'NOT'  => ['id' => $type_id],
+            ],
+        ]);
+        if ($existing->numrows() > 0) {
+            Session::addMessageAfterRedirect(
+                __s('A type with this name already exists.', 'genericobject'),
+                false,
+                ERROR,
+            );
+            return false;
+        }
+
+        $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
+        $reserved_pattern = $manager->getReservedSystemNamesPattern();
+        if (preg_match($reserved_pattern, $new_name) === 1) {
+            Session::addMessageAfterRedirect(
+                __s('This name is reserved by a native GLPI asset type.', 'genericobject'),
+                false,
+                ERROR,
+            );
+            return false;
+        }
+
+        $old_itemtype = $type->fields['itemtype'];
+        $new_itemtype = self::getClassByName($new_name);
+
+        $migration = new Migration(PLUGIN_GENERICOBJECT_VERSION);
+        self::applyTypeRename(
+            $migration,
+            $type_id,
+            $old_name,
+            $new_name,
+            $old_itemtype,
+            $new_itemtype,
+        );
+        ProfileRight::cleanAllPossibleRights();
+        $migration->executeMigration();
+
+        Session::addMessageAfterRedirect(
+            sprintf(
+                __s('Type "%s" has been renamed to "%s".', 'genericobject'),
+                $old_name,
+                $new_name,
+            ),
+            false,
+            INFO,
+        );
+
+        return true;
+    }
+
+    /**
+     * Get the list of reserved GLPI core asset names.
+     *
+     * @return string[]
+     */
+    public static function getReservedNames(): array
+    {
+        $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
+        $pattern = $manager->getReservedSystemNamesPattern();
+        if (preg_match('/\(([^)]+)\)/', $pattern, $matches)) {
+            return explode('|', $matches[1]);
+        }
+        return [];
     }
 
     /**

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -52,6 +52,8 @@ class PluginGenericobjectType extends CommonDBTM
 
     public const CAN_OPEN_TICKET             = 1024;
 
+    public const MAX_TYPE_NAME_LENGTH = 25;
+
     public $dohistory                 = true;
 
     public static $rightname          = 'plugin_genericobject_types';
@@ -920,6 +922,20 @@ class PluginGenericobjectType extends CommonDBTM
         if (preg_match($reserved_pattern, $new_name) === 1) {
             Session::addMessageAfterRedirect(
                 __s('This name is reserved by a native GLPI asset type.', 'genericobject'),
+                false,
+                ERROR,
+            );
+            return false;
+        }
+
+        $new_system_name = self::getSystemName($new_name);
+        if (strlen($new_system_name) > self::MAX_TYPE_NAME_LENGTH) {
+            Session::addMessageAfterRedirect(
+                sprintf(
+                    __s('The name "%s" is too long. The maximum allowed length is %d characters.', 'genericobject'),
+                    $new_system_name,
+                    self::MAX_TYPE_NAME_LENGTH,
+                ),
                 false,
                 ERROR,
             );

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1065,18 +1065,18 @@ class PluginGenericobjectType extends CommonDBTM
         global $DB;
 
         if ($old_itemtype != $new_itemtype && !str_starts_with($old_itemtype, 'Glpi\\CustomAsset\\')) {
-            self::renameItemtypeForFieldsPlugin($migration, $old_itemtype, $new_itemtype);
-            $migration->renameItemtype($old_itemtype, $new_itemtype);
-            if ($DB->tableExists(getTableForItemType($old_itemtype . 'Model'))) {
-                $migration->renameItemtype($old_itemtype . 'Model', $new_itemtype . 'Model');
+            // Apply the same rename (fields plugin fkeys, itemtype/table, other plugin tables) to the type
+            // itself and its Model/Type/Category companion dropdowns, as they can also be referenced elsewhere.
+            foreach (['', 'Model', 'Type', 'Category'] as $suffix) {
+                $old_variant_itemtype = $old_itemtype . $suffix;
+                $new_variant_itemtype = $new_itemtype . $suffix;
+                if ($suffix !== '' && !$DB->tableExists(getTableForItemType($old_variant_itemtype))) {
+                    continue;
+                }
+                self::renameItemtypeForFieldsPlugin($migration, $old_variant_itemtype, $new_variant_itemtype);
+                $migration->renameItemtype($old_variant_itemtype, $new_variant_itemtype);
+                self::applyPluginsTypeRename($migration, $old_variant_itemtype, $new_variant_itemtype);
             }
-            if ($DB->tableExists(getTableForItemType($old_itemtype . 'Type'))) {
-                $migration->renameItemtype($old_itemtype . 'Type', $new_itemtype . 'Type');
-            }
-            if ($DB->tableExists(getTableForItemType($old_itemtype . 'Category'))) {
-                $migration->renameItemtype($old_itemtype . 'Category', $new_itemtype . 'Category');
-            }
-            self::applyPluginsTypeRename($migration, $old_itemtype, $new_itemtype);
             $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
         }
 

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1012,8 +1012,8 @@ class PluginGenericobjectType extends CommonDBTM
             Session::addMessageAfterRedirect($e->getMessage(), false, ERROR);
             return false;
         }
-        ProfileRight::cleanAllPossibleRights();
         $migration->executeMigration();
+        ProfileRight::cleanAllPossibleRights();
 
         Session::addMessageAfterRedirect(
             sprintf(
@@ -1233,7 +1233,7 @@ class PluginGenericobjectType extends CommonDBTM
                 if ($DB->fieldExists($table_name, $fkey_newname)) {
                     throw new RuntimeException(
                         sprintf(
-                            'Field "%s" cannot be renamed in table "%s" as "%s" is field already exists.',
+                            'Field "%s" cannot be renamed in table "%s": field "%s" already exists.',
                             $fkey_oldname,
                             $table_name,
                             $fkey_newname,
@@ -1293,13 +1293,16 @@ class PluginGenericobjectType extends CommonDBTM
         // Get all plugin tables
         $tables_result = $DB->doQuery("SHOW TABLES LIKE 'glpi\\_plugin\\_%'");
 
+        $old_table = getTableForItemType($old_itemtype);
+        $new_table = getTableForItemType($new_itemtype);
+
         $table_names = [];
         while ($row = $DB->fetchRow($tables_result)) {
             $table_name = $row[0];
 
-            // Check if table name contains old itemtype and rename it
-            if (str_contains($table_name, strtolower($old_itemtype))) {
-                $new_table_name = str_replace(strtolower($old_itemtype), strtolower($new_itemtype), $table_name);
+            // Rename the itemtype's own table and any relation table derived from it (e.g. "..._users")
+            if (str_starts_with($table_name, $old_table)) {
+                $new_table_name = $new_table . substr($table_name, strlen($old_table));
                 $migration->renameTable($table_name, $new_table_name);
                 $table_name = $new_table_name;
             }

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -955,7 +955,7 @@ class PluginGenericobjectType extends CommonDBTM
                 $old_itemtype,
                 $new_itemtype,
             );
-        } catch (RuntimeException $e) { 
+        } catch (RuntimeException $e) {
             Session::addMessageAfterRedirect($e->getMessage(), false, ERROR);
             return false;
         }

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -139,10 +139,24 @@ class PluginGenericobjectType extends CommonDBTM
         return GENERICOBJECT_CLASS_PATH . "/" . self::getSystemName($name) . ".class.php";
     }
 
-
     public static function getCompleteItemClassFilename($name)
     {
         return GENERICOBJECT_CLASS_PATH . "/" . self::getSystemName($name) . "_item.class.php";
+    }
+
+    public static function getCompleteClassModelFilename($name)
+    {
+        return GENERICOBJECT_CLASS_PATH . "/" . self::getSystemName($name) . "model.class.php";
+    }
+
+    public static function getCompleteClassTypeFilename($name)
+    {
+        return GENERICOBJECT_CLASS_PATH . "/" . self::getSystemName($name) . "type.class.php";
+    }
+
+    public static function getCompleteClassCategoryFilename($name)
+    {
+        return GENERICOBJECT_CLASS_PATH . "/" . self::getSystemName($name) . "category.class.php";
     }
 
 
@@ -151,10 +165,39 @@ class PluginGenericobjectType extends CommonDBTM
         return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . ".form.php";
     }
 
-
     public static function getCompleteSearchFilename($name)
     {
         return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . ".php";
+    }
+
+    public static function getCompleteModelFormFilename($name)
+    {
+        return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . "model.form.php";
+    }
+
+    public static function getCompleteModelSearchFilename($name)
+    {
+        return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . "model.php";
+    }
+
+    public static function getCompleteTypeFormFilename($name)
+    {
+        return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . "type.form.php";
+    }
+
+    public static function getCompleteTypeSearchFilename($name)
+    {
+        return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . "type.php";
+    }
+
+    public static function getCompleteCategoryFormFilename($name)
+    {
+        return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . "category.form.php";
+    }
+
+    public static function getCompleteCategorySearchFilename($name)
+    {
+        return GENERICOBJECT_FRONT_PATH . "/" . self::getSystemName($name) . "category.php";
     }
 
 
@@ -184,12 +227,18 @@ class PluginGenericobjectType extends CommonDBTM
     public static function deleteFormFile($name)
     {
         self::deleteFile(self::getCompleteFormFilename($name));
+        self::deleteFile(self::getCompleteModelFormFilename($name));
+        self::deleteFile(self::getCompleteTypeFormFilename($name));
+        self::deleteFile(self::getCompleteCategoryFormFilename($name));
     }
 
 
     public static function deleteSearchFile($name)
     {
         self::deleteFile(self::getCompleteSearchFilename($name));
+        self::deleteFile(self::getCompleteModelSearchFilename($name));
+        self::deleteFile(self::getCompleteTypeSearchFilename($name));
+        self::deleteFile(self::getCompleteCategorySearchFilename($name));
     }
 
 
@@ -207,6 +256,10 @@ class PluginGenericobjectType extends CommonDBTM
     public static function deleteClassFile($name)
     {
         self::deleteFile(self::getCompleteClassFilename($name));
+        self::deleteFile(self::getCompleteItemClassFilename($name));
+        self::deleteFile(self::getCompleteClassModelFilename($name));
+        self::deleteFile(self::getCompleteClassTypeFilename($name));
+        self::deleteFile(self::getCompleteClassCategoryFilename($name));
     }
 
 
@@ -1014,6 +1067,9 @@ class PluginGenericobjectType extends CommonDBTM
         if ($old_itemtype != $new_itemtype && !str_starts_with($old_itemtype, 'Glpi\\CustomAsset\\')) {
             self::renameItemtypeForFieldsPlugin($migration, $old_itemtype, $new_itemtype);
             $migration->renameItemtype($old_itemtype, $new_itemtype);
+            $migration->renameItemtype($old_itemtype . 'Model', $new_itemtype . 'Model');
+            $migration->renameItemtype($old_itemtype . 'Type', $new_itemtype . 'Type');
+            $migration->renameItemtype($old_itemtype . 'Category', $new_itemtype . 'Category');
             self::applyPluginsTypeRename($migration, $old_itemtype, $new_itemtype);
             $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
         }
@@ -1030,8 +1086,17 @@ class PluginGenericobjectType extends CommonDBTM
         $destination_files = [
             self::getCompleteClassFilename($new_name),
             self::getCompleteItemClassFilename($new_name),
+            self::getCompleteClassModelFilename($new_name),
+            self::getCompleteClassTypeFilename($new_name),
+            self::getCompleteClassCategoryFilename($new_name),
             self::getCompleteFormFilename($new_name),
             self::getCompleteSearchFilename($new_name),
+            self::getCompleteModelFormFilename($new_name),
+            self::getCompleteModelSearchFilename($new_name),
+            self::getCompleteTypeFormFilename($new_name),
+            self::getCompleteTypeSearchFilename($new_name),
+            self::getCompleteCategoryFormFilename($new_name),
+            self::getCompleteCategorySearchFilename($new_name),
             self::getCompleteAjaxTabFilename($new_name),
             self::getCompleteInjectionFilename($new_name),
             self::getCompleteConstantFilename($new_name),

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -946,14 +946,19 @@ class PluginGenericobjectType extends CommonDBTM
         $new_itemtype = self::getClassByName($new_name);
 
         $migration = new Migration(PLUGIN_GENERICOBJECT_VERSION);
-        self::applyTypeRename(
-            $migration,
-            $type_id,
-            $old_name,
-            $new_name,
-            $old_itemtype,
-            $new_itemtype,
-        );
+        try {
+            self::applyTypeRename(
+                $migration,
+                $type_id,
+                $old_name,
+                $new_name,
+                $old_itemtype,
+                $new_itemtype,
+            );
+        } catch (RuntimeException $e) { 
+            Session::addMessageAfterRedirect($e->getMessage(), false, ERROR);
+            return false;
+        }
         ProfileRight::cleanAllPossibleRights();
         $migration->executeMigration();
 

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -857,8 +857,6 @@ class PluginGenericobjectType extends CommonDBTM
                 );
             }
         }
-
-        self::applyPluginsTypeRename($migration, $old_itemtype, $new_itemtype);
     }
 
     /**
@@ -1009,7 +1007,9 @@ class PluginGenericobjectType extends CommonDBTM
         global $DB;
 
         if ($old_itemtype != $new_itemtype && !str_starts_with($old_itemtype, 'Glpi\\CustomAsset\\')) {
+            self::renameItemtypeForFieldsPlugin($old_itemtype, $new_itemtype);
             $migration->renameItemtype($old_itemtype, $new_itemtype);
+            self::applyPluginsTypeRename($migration, $old_itemtype, $new_itemtype);
             $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
         }
 
@@ -1127,6 +1127,96 @@ class PluginGenericobjectType extends CommonDBTM
     }
 
     /**
+     * Rename itemtype for fields plugin and all its references.
+     */
+    private static function renameItemtypeForFieldsPlugin(
+        string $old_itemtype,
+        string $new_itemtype,
+    ): void
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $old_table = getTableForItemType($old_itemtype);
+        $new_table = getTableForItemType($new_itemtype);
+        $old_fkey  = getForeignKeyFieldForTable($old_table);
+        $new_fkey  = getForeignKeyFieldForTable($new_table);
+
+        // Get all foreign key columns referencing the old itemtype
+        $fkey_column_iterator = $DB->request(
+            [
+                'SELECT' => [
+                    'table_name AS TABLE_NAME',
+                    'column_name AS COLUMN_NAME',
+                ],
+                'FROM'   => 'information_schema.columns',
+                'WHERE'  => [
+                    'table_schema' => $DB->dbdefault,
+                    'table_name'   => ['LIKE', 'glpi\\_plugin\\_fields\\_%'],
+                    'OR' => [
+                        ['column_name'  => $old_fkey],
+                        ['column_name'  => ['LIKE', $old_fkey . '_%']],
+                    ],
+                ],
+            ]
+        );
+        foreach ($fkey_column_iterator as $fkey_column) {
+            $fkey_table   = $fkey_column['TABLE_NAME'];
+            $fkey_oldname = $fkey_column['COLUMN_NAME'];
+            $fkey_newname = preg_replace('/^' . preg_quote($old_fkey, '/') . '/', $new_fkey, $fkey_oldname);
+
+            // Check if new foreign key name already exists in the table
+            if ($DB->fieldExists($fkey_table, $fkey_newname)) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Field "%s" cannot be renamed in table "%s" as "%s" is field already exists.',
+                        $fkey_oldname,
+                        $fkey_table,
+                        $fkey_newname
+                    )
+                );
+            }
+
+            // Rename the foreign key column immediately so it is already updated when renameItemtype() scans all tables
+            if (!$DB->doQuery("ALTER TABLE `{$fkey_table}` RENAME COLUMN `{$fkey_oldname}` TO `{$fkey_newname}`")) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Failed to rename field "%s" to "%s" in table "%s": %s',
+                        $fkey_oldname,
+                        $fkey_newname,
+                        $fkey_table,
+                        $DB->error(),
+                    )
+                );
+            }
+        }
+
+        // Update the 'type' column in plugin fields that reference this itemtype
+        if ($DB->tableExists('glpi_plugin_fields_fields')) {
+            $DB->update(
+                'glpi_plugin_fields_fields',
+                [
+                    'type' => new QueryExpression(
+                        'REPLACE('
+                        . $DB->quoteName('type')
+                        . ', ' . $DB->quoteValue('dropdown-' . $old_itemtype)
+                        . ', ' . $DB->quoteValue('dropdown-' . $new_itemtype)
+                        . ')',
+                    ),
+                    'name' => new QueryExpression(
+                        'REPLACE('
+                        . $DB->quoteName('name')
+                        . ', ' . $DB->quoteValue($old_fkey)
+                        . ', ' . $DB->quoteValue($new_fkey)
+                        . ')',
+                    ),
+                ],
+                ['type' => ['LIKE', 'dropdown-' . $old_itemtype . '%']],
+            );
+        }
+    }
+
+    /**
      * Update all plugin data when a genericobject type is renamed.
      *
      * @param Migration $migration
@@ -1161,19 +1251,7 @@ class PluginGenericobjectType extends CommonDBTM
             $table_names[] = $table_name;
         }
 
-        try {
-            $migration->executeMigration();
-        } catch (Exception $e) {
-            Session::addMessageAfterRedirect(
-                sprintf(
-                    __s('An error occurred during the plugin tables rename: %s', 'genericobject'),
-                    $e->getMessage(),
-                ),
-                false,
-                ERROR,
-            );
-            return;
-        }
+        $migration->executeMigration();
 
         // Update itemtypes field by replacing old itemtype by new itemtype
         foreach ($table_names as $table_name) {

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1007,7 +1007,7 @@ class PluginGenericobjectType extends CommonDBTM
         global $DB;
 
         if ($old_itemtype != $new_itemtype && !str_starts_with($old_itemtype, 'Glpi\\CustomAsset\\')) {
-            self::renameItemtypeForFieldsPlugin($old_itemtype, $new_itemtype);
+            self::renameItemtypeForFieldsPlugin($migration, $old_itemtype, $new_itemtype);
             $migration->renameItemtype($old_itemtype, $new_itemtype);
             self::applyPluginsTypeRename($migration, $old_itemtype, $new_itemtype);
             $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
@@ -1130,6 +1130,7 @@ class PluginGenericobjectType extends CommonDBTM
      * Rename itemtype for fields plugin and all its references.
      */
     private static function renameItemtypeForFieldsPlugin(
+        Migration $migration,
         string $old_itemtype,
         string $new_itemtype,
     ): void
@@ -1143,77 +1144,69 @@ class PluginGenericobjectType extends CommonDBTM
         $new_fkey  = getForeignKeyFieldForTable($new_table);
 
         // Get all foreign key columns referencing the old itemtype
-        $fkey_column_iterator = $DB->request(
-            [
-                'SELECT' => [
-                    'table_name AS TABLE_NAME',
-                    'column_name AS COLUMN_NAME',
-                ],
-                'FROM'   => 'information_schema.columns',
-                'WHERE'  => [
-                    'table_schema' => $DB->dbdefault,
-                    'table_name'   => ['LIKE', 'glpi\\_plugin\\_fields\\_%'],
-                    'OR' => [
-                        ['column_name'  => $old_fkey],
-                        ['column_name'  => ['LIKE', $old_fkey . '_%']],
-                    ],
-                ],
-            ]
-        );
-        foreach ($fkey_column_iterator as $fkey_column) {
-            $fkey_table   = $fkey_column['TABLE_NAME'];
-            $fkey_oldname = $fkey_column['COLUMN_NAME'];
-            $fkey_newname = preg_replace('/^' . preg_quote($old_fkey, '/') . '/', $new_fkey, $fkey_oldname);
+        $fields_tables_result = $DB->doQuery("SHOW TABLES LIKE 'glpi\\_plugin\\_fields\\_%'");
+        if (!$fields_tables_result) {
+            return;
+        }
 
-            // Check if new foreign key name already exists in the table
-            if ($DB->fieldExists($fkey_table, $fkey_newname)) {
-                throw new RuntimeException(
-                    sprintf(
-                        'Field "%s" cannot be renamed in table "%s" as "%s" is field already exists.',
-                        $fkey_oldname,
-                        $fkey_table,
-                        $fkey_newname
-                    )
-                );
-            }
+        // For each table, find fields that are foreign keys to the old itemtype and rename them
+        while ($row = $DB->fetchRow($fields_tables_result)) {
+            $table_name = $row[0];
 
-            // Rename the foreign key column immediately so it is already updated when renameItemtype() scans all tables
-            if (!$DB->doQuery("ALTER TABLE `{$fkey_table}` RENAME COLUMN `{$fkey_oldname}` TO `{$fkey_newname}`")) {
-                throw new RuntimeException(
-                    sprintf(
-                        'Failed to rename field "%s" to "%s" in table "%s": %s',
-                        $fkey_oldname,
-                        $fkey_newname,
-                        $fkey_table,
-                        $DB->error(),
-                    )
-                );
+            // Fields to rename are those that are exactly the old foreign key or start with old foreign key followed by an underscore
+            $fields_to_rename = array_filter(
+                $DB->listFields($table_name),
+                fn($field) => $field === $old_fkey || str_starts_with($field, $old_fkey . '_'),
+                ARRAY_FILTER_USE_KEY,
+            );
+            foreach (array_keys($fields_to_rename) as $field) {
+                $fkey_oldname = $field;
+                $fkey_newname = preg_replace('/^' . preg_quote($old_fkey, '/') . '/', $new_fkey, $fkey_oldname);
+
+                // Check if new foreign key name already exists in the table
+                if ($DB->fieldExists($table_name, $fkey_newname)) {
+                    throw new RuntimeException(
+                        sprintf(
+                            'Field "%s" cannot be renamed in table "%s" as "%s" is field already exists.',
+                            $fkey_oldname,
+                            $table_name,
+                            $fkey_newname
+                        )
+                    );
+                }
+
+                // Rename the foreign key column immediately so it is already updated when renameItemtype() scans all tables
+                $migration->addPreQuery("ALTER TABLE `{$table_name}` RENAME COLUMN `{$fkey_oldname}` TO `{$fkey_newname}`");
             }
         }
 
         // Update the 'type' column in plugin fields that reference this itemtype
         if ($DB->tableExists('glpi_plugin_fields_fields')) {
-            $DB->update(
-                'glpi_plugin_fields_fields',
-                [
-                    'type' => new QueryExpression(
-                        'REPLACE('
-                        . $DB->quoteName('type')
-                        . ', ' . $DB->quoteValue('dropdown-' . $old_itemtype)
-                        . ', ' . $DB->quoteValue('dropdown-' . $new_itemtype)
-                        . ')',
-                    ),
-                    'name' => new QueryExpression(
-                        'REPLACE('
-                        . $DB->quoteName('name')
-                        . ', ' . $DB->quoteValue($old_fkey)
-                        . ', ' . $DB->quoteValue($new_fkey)
-                        . ')',
-                    ),
-                ],
-                ['type' => ['LIKE', 'dropdown-' . $old_itemtype . '%']],
+            $migration->addPostQuery(
+                $DB->buildUpdate(
+                    'glpi_plugin_fields_fields',
+                    [
+                        'type' => new QueryExpression(
+                            'REPLACE('
+                            . $DB->quoteName('type')
+                            . ', ' . $DB->quoteValue('dropdown-' . $old_itemtype)
+                            . ', ' . $DB->quoteValue('dropdown-' . $new_itemtype)
+                            . ')',
+                        ),
+                        'name' => new QueryExpression(
+                            'REPLACE('
+                            . $DB->quoteName('name')
+                            . ', ' . $DB->quoteValue($old_fkey)
+                            . ', ' . $DB->quoteValue($new_fkey)
+                            . ')',
+                        ),
+                    ],
+                    ['type' => ['LIKE', 'dropdown-' . $old_itemtype]],
+                )
             );
         }
+
+        $migration->executeMigration();
     }
 
     /**

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1067,9 +1067,15 @@ class PluginGenericobjectType extends CommonDBTM
         if ($old_itemtype != $new_itemtype && !str_starts_with($old_itemtype, 'Glpi\\CustomAsset\\')) {
             self::renameItemtypeForFieldsPlugin($migration, $old_itemtype, $new_itemtype);
             $migration->renameItemtype($old_itemtype, $new_itemtype);
-            $migration->renameItemtype($old_itemtype . 'Model', $new_itemtype . 'Model');
-            $migration->renameItemtype($old_itemtype . 'Type', $new_itemtype . 'Type');
-            $migration->renameItemtype($old_itemtype . 'Category', $new_itemtype . 'Category');
+            if ($DB->tableExists(getTableForItemType($old_itemtype . 'Model'))) {
+                $migration->renameItemtype($old_itemtype . 'Model', $new_itemtype . 'Model');
+            }
+            if ($DB->tableExists(getTableForItemType($old_itemtype . 'Type'))) {
+                $migration->renameItemtype($old_itemtype . 'Type', $new_itemtype . 'Type');
+            }
+            if ($DB->tableExists(getTableForItemType($old_itemtype . 'Category'))) {
+                $migration->renameItemtype($old_itemtype . 'Category', $new_itemtype . 'Category');
+            }
             self::applyPluginsTypeRename($migration, $old_itemtype, $new_itemtype);
             $migration->executeMigration(); // Execute migration to flush updates on tables that may be renamed
         }

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1301,7 +1301,7 @@ class PluginGenericobjectType extends CommonDBTM
             $table_name = $row[0];
 
             // Rename the itemtype's own table and any relation table derived from it (e.g. "..._users")
-            if (str_starts_with($table_name, $old_table)) {
+            if ($table_name === $old_table || str_starts_with($table_name, $old_table . '_')) {
                 $new_table_name = $new_table . substr($table_name, strlen($old_table));
                 $migration->renameTable($table_name, $new_table_name);
                 $table_name = $new_table_name;

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -27,7 +27,7 @@
  * @link      https://github.com/pluginsGLPI/genericobject
  * -------------------------------------------------------------------------
  */
-
+use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\QueryExpression;
 
 class PluginGenericobjectType extends CommonDBTM
@@ -913,7 +913,7 @@ class PluginGenericobjectType extends CommonDBTM
             return false;
         }
 
-        $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
+        $manager = AssetDefinitionManager::getInstance();
         $reserved_pattern = $manager->getReservedSystemNamesPattern();
         if (preg_match($reserved_pattern, $new_name) === 1) {
             Session::addMessageAfterRedirect(
@@ -977,7 +977,7 @@ class PluginGenericobjectType extends CommonDBTM
      */
     public static function getReservedNames(): array
     {
-        $manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
+        $manager = AssetDefinitionManager::getInstance();
         $pattern = $manager->getReservedSystemNamesPattern();
         if (preg_match('/\(([^)]+)\)/', $pattern, $matches)) {
             return explode('|', $matches[1]);
@@ -1133,8 +1133,7 @@ class PluginGenericobjectType extends CommonDBTM
         Migration $migration,
         string $old_itemtype,
         string $new_itemtype,
-    ): void
-    {
+    ): void {
         /** @var DBmysql $DB */
         global $DB;
 
@@ -1145,9 +1144,6 @@ class PluginGenericobjectType extends CommonDBTM
 
         // Get all foreign key columns referencing the old itemtype
         $fields_tables_result = $DB->doQuery("SHOW TABLES LIKE 'glpi\\_plugin\\_fields\\_%'");
-        if (!$fields_tables_result) {
-            return;
-        }
 
         // For each table, find fields that are foreign keys to the old itemtype and rename them
         while ($row = $DB->fetchRow($fields_tables_result)) {
@@ -1170,8 +1166,8 @@ class PluginGenericobjectType extends CommonDBTM
                             'Field "%s" cannot be renamed in table "%s" as "%s" is field already exists.',
                             $fkey_oldname,
                             $table_name,
-                            $fkey_newname
-                        )
+                            $fkey_newname,
+                        ),
                     );
                 }
 
@@ -1202,7 +1198,7 @@ class PluginGenericobjectType extends CommonDBTM
                         ),
                     ],
                     ['type' => ['LIKE', 'dropdown-' . $old_itemtype]],
-                )
+                ),
             );
         }
 
@@ -1226,9 +1222,6 @@ class PluginGenericobjectType extends CommonDBTM
 
         // Get all plugin tables
         $tables_result = $DB->doQuery("SHOW TABLES LIKE 'glpi\\_plugin\\_%'");
-        if (!$tables_result) {
-            return;
-        }
 
         $table_names = [];
         while ($row = $DB->fetchRow($tables_result)) {

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -858,7 +858,7 @@ class PluginGenericobjectType extends CommonDBTM
             }
         }
 
-        self::applyPluginsRename($migration, $old_itemtype, $new_itemtype);
+        self::applyPluginsTypeRename($migration, $old_itemtype, $new_itemtype);
     }
 
     /**
@@ -897,10 +897,6 @@ class PluginGenericobjectType extends CommonDBTM
                 ERROR,
             );
             return false;
-        }
-
-        if ($new_name === $old_name) {
-            return true;
         }
 
         $existing = $DB->request([
@@ -942,6 +938,10 @@ class PluginGenericobjectType extends CommonDBTM
                 ERROR,
             );
             return false;
+        }
+
+        if ($new_name === $old_name) {
+            return true;
         }
 
         $old_itemtype = $type->fields['itemtype'];
@@ -1133,7 +1133,7 @@ class PluginGenericobjectType extends CommonDBTM
      * @param string    $old_itemtype  Old itemtype class name
      * @param string    $new_itemtype  New itemtype class name
      */
-    private static function applyPluginsRename(
+    private static function applyPluginsTypeRename(
         Migration $migration,
         string $old_itemtype,
         string $new_itemtype,
@@ -1141,19 +1141,48 @@ class PluginGenericobjectType extends CommonDBTM
         /** @var DBmysql $DB */
         global $DB;
 
-        $columns = $DB->request([
-            'SELECT' => ['TABLE_NAME'],
-            'FROM'   => 'information_schema.COLUMNS',
-            'WHERE'  => [
-                'TABLE_SCHEMA' => $DB->dbdefault,
-                'TABLE_NAME'   => ['LIKE', 'glpi\_plugin\_%'],
-                'COLUMN_NAME'  => 'itemtypes',
-            ],
-        ]);
+        // Get all plugin tables
+        $tables_result = $DB->doQuery("SHOW TABLES LIKE 'glpi\\_plugin\\_%'");
+        if (!$tables_result) {
+            return;
+        }
 
-        foreach ($columns as $row) {
+        $table_names = [];
+        while ($row = $DB->fetchRow($tables_result)) {
+            $table_name = $row[0];
+
+            // Check if table name contains old itemtype and rename it
+            if (str_contains($table_name, strtolower($old_itemtype))) {
+                $new_table_name = str_replace(strtolower($old_itemtype), strtolower($new_itemtype), $table_name);
+                $migration->renameTable($table_name, $new_table_name);
+                $table_name = $new_table_name;
+            }
+
+            $table_names[] = $table_name;
+        }
+
+        try {
+            $migration->executeMigration();
+        } catch (Exception $e) {
+            Session::addMessageAfterRedirect(
+                sprintf(
+                    __s('An error occurred during the plugin tables rename: %s', 'genericobject'),
+                    $e->getMessage(),
+                ),
+                false,
+                ERROR,
+            );
+            return;
+        }
+
+        // Update itemtypes field by replacing old itemtype by new itemtype
+        foreach ($table_names as $table_name) {
+            if (!$DB->fieldExists($table_name, 'itemtypes')) {
+                continue;
+            }
+
             $DB->update(
-                $row['TABLE_NAME'],
+                $table_name,
                 [
                     'itemtypes' => new QueryExpression(
                         'REPLACE('

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -27,9 +27,13 @@
  #}
 
 {% set conflict_count = 0 %}
+{% set too_long_count = 0 %}
 {% for genericobject_type in genericobject_types %}
     {% if genericobject_type.name|lower in reserved_names and customassets[genericobject_type.name] is not defined %}
         {% set conflict_count = conflict_count + 1 %}
+    {% endif %}
+    {% if genericobject_type.name|length > constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') and customassets[genericobject_type.name] is not defined %}
+        {% set too_long_count = too_long_count + 1 %}
     {% endif %}
 {% endfor %}
 
@@ -70,6 +74,28 @@
                 </div>
             </div>
         </div>
+
+        {# Name Too Long Banner — only shown when types exceed the max name length #}
+        {% if too_long_count > 0 %}
+            <div class="alert alert-danger border-start border-danger border-2 mb-4">
+                <div class="d-flex align-items-start">
+                    <i class="ti ti-alert-circle text-danger me-3 mt-1 fa-lg"></i>
+                    <div>
+                        <h5 class="alert-heading mb-2">
+                            {{ __('Name too long', 'genericobject') }}
+                            <span class="badge bg-danger ms-2">{{ too_long_count }}</span>
+                        </h5>
+                        <p class="mb-0">
+                            {% if too_long_count == 1 %}
+                                {{ __('1 type has a name that exceeds the maximum allowed length of %d characters. Please rename it manually before migrating.', 'genericobject')|format(constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH')) }}
+                            {% else %}
+                                {{ (too_long_count ~ ' ' ~ __('types have names that exceed the maximum allowed length of %d characters and cannot be automatically renamed. Please rename them manually before migrating.', 'genericobject'))|format(constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH')) }}
+                            {% endif %}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
 
         {# Name Conflict Banner — only shown when conflicts exist #}
         {% if conflict_count > 0 %}
@@ -123,18 +149,21 @@
                 <div class="d-flex flex-wrap justify-content-start gap-3">
                     {% for key, genericobject_type in paginated_types %}
                         {% set is_conflicting = genericobject_type.name|lower in reserved_names and customassets[genericobject_type.name] is not defined %}
+                        {% set is_too_long = genericobject_type.name|length > constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') and customassets[genericobject_type.name] is not defined %}
                         {% set modal_id = 'rename-modal-' ~ genericobject_type.id %}
                         <div class="card shadow-sm mb-2 d-flex flex-column h-100" style="flex: 0 0 calc(33.333% - 1rem);">
                             <div class="card-header d-flex align-items-center
                                         {% if customassets[genericobject_type.name] is defined %}
                                             bg-success bg-opacity-10 text-success
-                                        {% elseif is_conflicting %}
+                                        {% elseif is_conflicting or is_too_long %}
                                             bg-warning bg-opacity-10 text-warning
                                         {% else %}
                                             bg-danger bg-opacity-10 text-danger
                                         {% endif %}">
                                 {% if is_conflicting %}
                                     <i class="ti ti-alert-triangle fa-lg me-2 text-warning" title="{{ __('Name conflict: cannot be migrated', 'genericobject') }}"></i>
+                                {% elseif is_too_long %}
+                                    <i class="ti ti-alert-triangle fa-lg me-2 text-warning" title="{{ __('Name too long: cannot be automatically renamed', 'genericobject') }}"></i>
                                 {% elseif customassets[genericobject_type.name] is defined and customassets[genericobject_type.name].icon %}
                                     <i class="{{ customassets[genericobject_type.name].icon }} fa-lg me-2"></i>
                                 {% else %}
@@ -145,6 +174,10 @@
                                     {% if is_conflicting %}
                                         <span class="badge bg-warning text-dark ms-1">
                                             {{ __('Conflict', 'genericobject') }}
+                                        </span>
+                                    {% elseif is_too_long %}
+                                        <span class="badge bg-warning text-dark ms-1">
+                                            {{ __('Name too long', 'genericobject') }}
                                         </span>
                                     {% endif %}
                                 </h3>
@@ -176,7 +209,7 @@
                                     </div>
                                 {% else %}
                                     <div class="mb-2">
-                                        {% if is_conflicting %}
+                                        {% if is_conflicting or is_too_long %}
                                             <i class="ti ti-alert-circle text-warning me-2"></i>
                                             <span class="text-warning fw-bold">{{ __('Cannot Migrate', 'genericobject') }}</span>
                                         {% else %}
@@ -189,6 +222,13 @@
                                             <small class="text-muted">
                                                 <i class="ti ti-info-circle me-1"></i>
                                                 {{ __('The name "%s" is reserved by a native GLPI asset type.')|format(genericobject_type.name) }}
+                                            </small>
+                                        </div>
+                                    {% elseif is_too_long %}
+                                        <div class="mb-2">
+                                            <small class="text-muted">
+                                                <i class="ti ti-info-circle me-1"></i>
+                                                {{ __('The name "%s" exceeds the maximum allowed length of %d characters. Please rename it manually.')|format(genericobject_type.name, constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH')) }}
                                             </small>
                                         </div>
                                     {% endif %}

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -243,14 +243,26 @@
                                                     {{ __('New name', 'genericobject') }}
                                                 </label>
                                                 <input type="text"
-                                                       id="{{ modal_id }}-input"
-                                                       name="new_name"
-                                                       class="form-control"
-                                                       value="{{ genericobject_type.name }}"
-                                                       pattern="[a-zA-Z][a-zA-Z0-9]*"
-                                                       title="{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}"
-                                                       required>
-                                                <small class="text-muted">{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}</small>
+                                                    id="{{ modal_id }}-input"
+                                                    name="new_name"
+                                                    class="form-control"
+                                                    value="{{ genericobject_type.name }}"
+                                                    pattern="[a-zA-Z][a-zA-Z0-9]*"
+                                                    maxlength="{{ constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') }}"
+                                                    title="{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}"
+                                                    data-counter-target="{{ modal_id }}-counter"
+                                                    data-warning-target="{{ modal_id }}-length-warning"
+                                                    oninput="glpiGenericobjectUpdateCounter(this)"
+                                                    required
+                                                >
+                                                <div class="d-flex justify-content-between align-items-center mt-1">
+                                                    <small class="text-muted">{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}</small>
+                                                    <small id="{{ modal_id }}-counter" class="text-muted">{{ genericobject_type.name|length }}/{{ constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') }}</small>
+                                                </div>
+                                                <div id="{{ modal_id }}-length-warning" class="text-danger small mt-1 d-none">
+                                                    <i class="ti ti-alert-circle me-1"></i>
+                                                    {{ __('Maximum length of %d characters reached.', 'genericobject')|format(constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH')) }}
+                                                </div>
                                             </div>
                                             <div class="modal-footer">
                                                 <button type="button" class="btn btn-ghost-secondary" data-bs-dismiss="modal">
@@ -400,6 +412,40 @@
     }
 </style>
 <script>
+    function glpiGenericobjectUpdateCounter(input) {
+        const maxLen = parseInt(input.getAttribute('maxlength'));
+        const currentLen = input.value.length;
+        const counterId = input.dataset.counterTarget;
+        const warningId = input.dataset.warningTarget;
+        const counter = counterId ? document.getElementById(counterId) : null;
+        const warning = warningId ? document.getElementById(warningId) : null;
+
+        if (counter) {
+            counter.textContent = currentLen + '/' + maxLen;
+            counter.className = 'small';
+            if (currentLen >= maxLen) {
+                counter.classList.add('text-danger', 'fw-bold');
+            } else {
+                counter.classList.add('text-muted');
+            }
+        }
+
+        if (warning) {
+            if (currentLen >= maxLen) {
+                warning.classList.remove('d-none');
+            } else {
+                warning.classList.add('d-none');
+            }
+        }
+    }
+
+    document.addEventListener('shown.bs.modal', function (event) {
+        const input = event.target.querySelector('[data-counter-target]');
+        if (input) {
+            glpiGenericobjectUpdateCounter(input);
+        }
+    });
+
     function copyCode() {
         const codeBlock = document.getElementById('codeBlock');
         const textArea = document.createElement('textarea');

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -26,6 +26,13 @@
  # -------------------------------------------------------------------------
  #}
 
+{% set conflict_count = 0 %}
+{% for genericobject_type in genericobject_types %}
+    {% if genericobject_type.name|lower in reserved_names and customassets[genericobject_type.name] is not defined %}
+        {% set conflict_count = conflict_count + 1 %}
+    {% endif %}
+{% endfor %}
+
 {# Page Header #}
 <div class="d-flex align-items-center mb-4">
     <div class="me-3">
@@ -37,8 +44,7 @@
     </div>
 </div>
 <div class="row">
-    <div
-        class="col-12">
+    <div class="col-12">
         {# EOL Warning Banner #}
         <div class="alert alert-warning border-start border-warning border-2 mb-4">
             <div class="d-flex align-items-start">
@@ -51,6 +57,41 @@
                 </div>
             </div>
         </div>
+
+        {# Rename Info Banner #}
+        <div class="alert alert-primary border-start border-primary border-2 mb-4">
+            <div class="d-flex align-items-start">
+                <i class="ti ti-pencil text-primary me-3 mt-1 fa-lg"></i>
+                <div>
+                    <h5 class="alert-heading mb-2">{{ __('Name Conflict?', 'genericobject') }}</h5>
+                    <p class="mb-0">
+                        {{ __('If a GenericObject type shares the same name as a native GLPI asset (e.g. Printer, Computer), migration will fail. Use the Rename button on the relevant card below to resolve the conflict before migrating.', 'genericobject') }}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        {# Name Conflict Banner — only shown when conflicts exist #}
+        {% if conflict_count > 0 %}
+            <div class="alert alert-danger border-start border-danger border-2 mb-4">
+                <div class="d-flex align-items-start">
+                    <i class="ti ti-alert-circle text-danger me-3 mt-1 fa-lg"></i>
+                    <div>
+                        <h5 class="alert-heading mb-2">
+                            {{ __('Name Conflict detected', 'genericobject') }}
+                            <span class="badge bg-danger ms-2">{{ conflict_count }}</span>
+                        </h5>
+                        <p class="mb-0">
+                            {% if conflict_count == 1 %}
+                                {{ __('1 type cannot be migrated because its name is reserved by a native GLPI asset. Use the Rename button on the card below to fix it before migrating.', 'genericobject') }}
+                            {% else %}
+                                {{ conflict_count ~ ' ' ~ __('types cannot be migrated because their names are reserved by native GLPI assets. Use the Rename button on the cards below to fix them before migrating.', 'genericobject') }}
+                            {% endif %}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
 
         {# Migration Status Card #}
         <div class="card shadow-sm mb-4">
@@ -81,20 +122,31 @@
 
                 <div class="d-flex flex-wrap justify-content-start gap-3">
                     {% for key, genericobject_type in paginated_types %}
+                        {% set is_conflicting = genericobject_type.name|lower in reserved_names and customassets[genericobject_type.name] is not defined %}
+                        {% set modal_id = 'rename-modal-' ~ genericobject_type.id %}
                         <div class="card shadow-sm mb-2 d-flex flex-column h-100" style="flex: 0 0 calc(33.333% - 1rem);">
                             <div class="card-header d-flex align-items-center
                                         {% if customassets[genericobject_type.name] is defined %}
                                             bg-success bg-opacity-10 text-success
+                                        {% elseif is_conflicting %}
+                                            bg-warning bg-opacity-10 text-warning
                                         {% else %}
                                             bg-danger bg-opacity-10 text-danger
                                         {% endif %}">
-                                {% if customassets[genericobject_type.name] is defined and customassets[genericobject_type.name].icon %}
+                                {% if is_conflicting %}
+                                    <i class="ti ti-alert-triangle fa-lg me-2 text-warning" title="{{ __('Name conflict: cannot be migrated', 'genericobject') }}"></i>
+                                {% elseif customassets[genericobject_type.name] is defined and customassets[genericobject_type.name].icon %}
                                     <i class="{{ customassets[genericobject_type.name].icon }} fa-lg me-2"></i>
                                 {% else %}
                                     <i class="ti ti-box fa-lg me-2"></i>
                                 {% endif %}
                                 <h3 class="card-title mb-0">
                                     {{ genericobject_type.name }}
+                                    {% if is_conflicting %}
+                                        <span class="badge bg-warning text-dark ms-1">
+                                            {{ __('Conflict', 'genericobject') }}
+                                        </span>
+                                    {% endif %}
                                 </h3>
                             </div>
 
@@ -111,12 +163,12 @@
                                         </span>
                                     </div>
                                     <div class="mt-auto d-flex justify-content-end gap-2">
-                                        <a href="{{ CFG_GLPI.root_doc }}/front/asset/asset.php?class={{ customassets[genericobject_type.name].system_name }}"
+                                        <a href="{{ config('root_doc') }}/front/asset/asset.php?class={{ customassets[genericobject_type.name].system_name }}"
                                         class="btn btn-outline-primary">
                                             <i class="ti ti-list me-2"></i>
                                             {{ __('View Items', 'genericobject') }}
                                         </a>
-                                        <a href="{{ CFG_GLPI.root_doc }}/front/asset/assetdefinition.form.php?id={{ customassets[genericobject_type.name].id }}"
+                                        <a href="{{ config('root_doc') }}/front/asset/assetdefinition.form.php?id={{ customassets[genericobject_type.name].id }}"
                                         class="btn btn-outline-success">
                                             <i class="ti ti-eye me-2"></i>
                                             {{ __('View Asset', 'genericobject') }}
@@ -124,9 +176,22 @@
                                     </div>
                                 {% else %}
                                     <div class="mb-2">
-                                        <i class="ti ti-x text-danger me-2"></i>
-                                        <span class="text-danger fw-bold">{{ __('Not Migrated', 'genericobject') }}</span>
+                                        {% if is_conflicting %}
+                                            <i class="ti ti-alert-circle text-warning me-2"></i>
+                                            <span class="text-warning fw-bold">{{ __('Cannot Migrate', 'genericobject') }}</span>
+                                        {% else %}
+                                            <i class="ti ti-x text-danger me-2"></i>
+                                            <span class="text-danger fw-bold">{{ __('Not Migrated', 'genericobject') }}</span>
+                                        {% endif %}
                                     </div>
+                                    {% if is_conflicting %}
+                                        <div class="mb-2">
+                                            <small class="text-muted">
+                                                <i class="ti ti-info-circle me-1"></i>
+                                                {{ __('The name "%s" is reserved by a native GLPI asset type.')|format(genericobject_type.name) }}
+                                            </small>
+                                        </div>
+                                    {% endif %}
                                     <div class="mb-2">
                                         <strong>{{ __('Items Migrated:', 'genericobject') }}</strong>
                                         <span class="badge glpi-badge">0</span>
@@ -136,6 +201,13 @@
                                             <i class="ti ti-list me-2"></i>
                                             {{ __('View Items', 'genericobject') }}
                                         </button>
+                                        <button type="button"
+                                                class="btn btn-outline-warning"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#{{ modal_id }}">
+                                            <i class="ti ti-pencil me-2"></i>
+                                            {{ __('Rename', 'genericobject') }}
+                                        </button>
                                         <button class="btn btn-outline-secondary" disabled>
                                             <i class="ti ti-eye me-2"></i>
                                             {{ __('View Asset', 'genericobject') }}
@@ -144,6 +216,57 @@
                                 {% endif %}
                             </div>
                         </div>
+
+                        {# Rename Modal for non-migrated types #}
+                        {% if customassets[genericobject_type.name] is not defined %}
+                            <div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-labelledby="{{ modal_id }}-label" aria-hidden="true">
+                                <div class="modal-dialog modal-dialog-centered">
+                                    <div class="modal-content">
+                                        <form method="post" action="{{ config('root_doc') }}/plugins/genericobject/front/migration_status.php">
+                                            <input type="hidden" name="type_id" value="{{ genericobject_type.id }}">
+                                            <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title" id="{{ modal_id }}-label">
+                                                    <i class="ti ti-pencil me-2"></i>
+                                                    {{ __('Rename "%s"', 'genericobject')|format(genericobject_type.name) }}
+                                                </h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close') }}"></button>
+                                            </div>
+                                            <div class="modal-body">
+                                                {% if is_conflicting %}
+                                                    <div class="alert alert-warning mb-3">
+                                                        <i class="ti ti-alert-triangle me-2"></i>
+                                                        {{ __('The name "%s" conflicts with a native GLPI asset type. Choose a different name to allow migration.', 'genericobject')|format(genericobject_type.name) }}
+                                                    </div>
+                                                {% endif %}
+                                                <label class="form-label" for="{{ modal_id }}-input">
+                                                    {{ __('New name', 'genericobject') }}
+                                                </label>
+                                                <input type="text"
+                                                       id="{{ modal_id }}-input"
+                                                       name="new_name"
+                                                       class="form-control"
+                                                       value="{{ genericobject_type.name }}"
+                                                       pattern="[a-zA-Z][a-zA-Z0-9]*"
+                                                       title="{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}"
+                                                       required>
+                                                <small class="text-muted">{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}</small>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-ghost-secondary" data-bs-dismiss="modal">
+                                                    {{ __('Cancel') }}
+                                                </button>
+                                                <button type="submit" class="btn btn-warning">
+                                                    <i class="ti ti-pencil me-1"></i>
+                                                    {{ __('Rename', 'genericobject') }}
+                                                </button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endif %}
+
                     {% endfor %}
                 </div>
                 {# Display pagination controls at the bottom #}
@@ -165,7 +288,7 @@
                     {{ __('How to Migrate', 'genericobject') }}
                 </h3>
             </div>
-                <div class="card-body">
+            <div class="card-body">
                     <div class="alert alert-warning border-start border-warning border-2 mb-4">
                         <div class="d-flex align-items-start">
                             <i class="ti ti-terminal-2 text-warning me-3 mt-1"></i>
@@ -212,6 +335,7 @@
 
                 </div>
             </div>
+        </div>
 
         {# Next Steps Card #}
         <div class="card shadow-sm mb-4">

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -34,7 +34,7 @@
     {% if genericobject_type.name|lower in reserved_names and customassets[genericobject_type.name] is not defined %}
         {% set conflict_count = conflict_count + 1 %}
     {% endif %}
-    {% if genericobject_type.name|length > constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') and customassets[genericobject_type.name] is not defined %}
+    {% if call('PluginGenericobjectType::getSystemName', [genericobject_type.name])|length > constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') and customassets[genericobject_type.name] is not defined %}
         {% set too_long_count = too_long_count + 1 %}
     {% endif %}
 {% endfor %}
@@ -111,17 +111,18 @@
                 <div class="d-flex flex-wrap justify-content-start gap-3">
                     {% for key, genericobject_type in paginated_types %}
                         {% set is_conflicting = genericobject_type.name|lower in reserved_names and customassets[genericobject_type.name] is not defined %}
-                        {% set is_too_long = genericobject_type.name|length > constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') and customassets[genericobject_type.name] is not defined %}
+                        {% set is_too_long = call('PluginGenericobjectType::getSystemName', [genericobject_type.name])|length > constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') and customassets[genericobject_type.name] is not defined %}
                         {% set modal_id = 'rename-modal-' ~ genericobject_type.id %}
                         <div class="card shadow-sm mb-2 d-flex flex-column h-100" style="flex: 0 0 calc(33.333% - 1rem);">
                             <div class="card-header d-flex align-items-center
-                                        {% if customassets[genericobject_type.name] is defined %}
-                                            bg-success bg-opacity-10 text-success
-                                        {% elseif is_conflicting or is_too_long %}
-                                            bg-warning bg-opacity-10 text-warning
-                                        {% else %}
-                                            bg-danger bg-opacity-10 text-danger
-                                        {% endif %}">
+                                {% if customassets[genericobject_type.name] is defined %}
+                                    bg-success bg-opacity-10 text-success
+                                {% elseif is_conflicting or is_too_long %}
+                                    bg-warning bg-opacity-10 text-warning
+                                {% else %}
+                                    bg-danger bg-opacity-10 text-danger
+                                {% endif %}"
+                            >
                                 {% if is_conflicting %}
                                     <i class="ti ti-alert-triangle fa-lg me-2 text-warning" title="{{ __('Name conflict: cannot be migrated', 'genericobject') }}"></i>
                                 {% elseif is_too_long %}

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -272,7 +272,7 @@
                                                     </div>
                                                     <small id="{{ modal_id }}-counter"
                                                         class="text-muted flex-shrink-0">
-                                                        {{ genericobject_type.name|length }}/{{ constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') }}
+                                                        {{ call('PluginGenericobjectType::getSystemName', [genericobject_type.name])|length }}/{{ constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') }}
                                                     </small>
                                                 </div>
                                                 <div>

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -260,24 +260,20 @@
                                                     required
                                                 >
                                                 <div class="d-flex justify-content-between align-items-center mt-1">
-    
                                                     <div class="d-flex flex-grow-1 gap-2" style="min-width: 0;">
                                                         <small class="text-muted">
                                                             {{ __('Use system name:', 'genericobject') }}
                                                         </small>
-
                                                         <small id="{{ modal_id }}-result"
                                                             class="text-muted fw-bold text-truncate"
                                                             style="min-width: 0; max-width: 50%;">
                                                             {{ call('PluginGenericobjectType::getSystemName', [genericobject_type.name]) }}
                                                         </small>
                                                     </div>
-
                                                     <small id="{{ modal_id }}-counter"
                                                         class="text-muted flex-shrink-0">
                                                         {{ genericobject_type.name|length }}/{{ constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') }}
                                                     </small>
-
                                                 </div>
                                                 <div>
                                                     <small class="text-muted">{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}</small>

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -255,12 +255,32 @@
                                                     title="{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}"
                                                     data-counter-target="{{ modal_id }}-counter"
                                                     data-warning-target="{{ modal_id }}-length-warning"
+                                                    data-result-target="{{ modal_id }}-result"
                                                     oninput="glpiGenericobjectUpdateCounter(this)"
                                                     required
                                                 >
                                                 <div class="d-flex justify-content-between align-items-center mt-1">
+    
+                                                    <div class="d-flex flex-grow-1 gap-2" style="min-width: 0;">
+                                                        <small class="text-muted">
+                                                            {{ __('Use system name:', 'genericobject') }}
+                                                        </small>
+
+                                                        <small id="{{ modal_id }}-result"
+                                                            class="text-muted fw-bold text-truncate"
+                                                            style="min-width: 0; max-width: 50%;">
+                                                            {{ call('PluginGenericobjectType::getSystemName', [genericobject_type.name]) }}
+                                                        </small>
+                                                    </div>
+
+                                                    <small id="{{ modal_id }}-counter"
+                                                        class="text-muted flex-shrink-0">
+                                                        {{ genericobject_type.name|length }}/{{ constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') }}
+                                                    </small>
+
+                                                </div>
+                                                <div>
                                                     <small class="text-muted">{{ __('Only letters and numbers, must start with a letter.', 'genericobject') }}</small>
-                                                    <small id="{{ modal_id }}-counter" class="text-muted">{{ genericobject_type.name|length }}/{{ constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH') }}</small>
                                                 </div>
                                                 <div id="{{ modal_id }}-length-warning" class="text-danger small mt-1 d-none">
                                                     <i class="ti ti-alert-circle me-1"></i>
@@ -417,29 +437,42 @@
 <script>
     function glpiGenericobjectUpdateCounter(input) {
         const maxLen = parseInt(input.getAttribute('maxlength'));
-        const currentLen = input.value.length;
         const counterId = input.dataset.counterTarget;
         const warningId = input.dataset.warningTarget;
+        const resultId = input.dataset.resultTarget;
         const counter = counterId ? document.getElementById(counterId) : null;
         const warning = warningId ? document.getElementById(warningId) : null;
+        const result = resultId ? document.getElementById(resultId) : null;
 
-        if (counter) {
-            counter.textContent = currentLen + '/' + maxLen;
-            counter.className = 'small';
-            if (currentLen >= maxLen) {
-                counter.classList.add('text-danger', 'fw-bold');
-            } else {
-                counter.classList.add('text-muted');
+        fetch(
+            '{{ config('root_doc') }}/plugins/genericobject/front/migration_status.php?action=get_system_name&name=' + encodeURIComponent(input.value),
+        )
+        .then(r => r.json())
+        .then(data => {
+            const currentLen = data.system_name.length;
+            if (counter) {
+                counter.textContent = currentLen + '/' + maxLen;
+                counter.className = 'small';
+                if (currentLen >= maxLen) {
+                    counter.classList.add('text-danger', 'fw-bold');
+                } else {
+                    counter.classList.add('text-muted');
+                }
             }
-        }
 
-        if (warning) {
-            if (currentLen >= maxLen) {
-                warning.classList.remove('d-none');
-            } else {
-                warning.classList.add('d-none');
+            if (warning) {
+                if (currentLen >= maxLen) {
+                    warning.classList.remove('d-none');
+                } else {
+                    warning.classList.add('d-none');
+                }
             }
-        }
+
+            if (result) {
+                result.textContent = data.system_name;
+            }
+        })
+        .catch((e) => console.error(e.message));
     }
 
     document.addEventListener('shown.bs.modal', function (event) {

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -26,6 +26,8 @@
  # -------------------------------------------------------------------------
  #}
 
+{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% set conflict_count = 0 %}
 {% set too_long_count = 0 %}
 {% for genericobject_type in genericobject_types %}
@@ -49,74 +51,34 @@
 </div>
 <div class="row">
     <div class="col-12">
-        {# EOL Warning Banner #}
-        <div class="alert alert-warning border-start border-warning border-2 mb-4">
-            <div class="d-flex align-items-start">
-                <i class="ti ti-alert-triangle text-warning me-3 mt-1 fa-lg"></i>
-                <div>
-                    <h5 class="alert-heading mb-2">{{ __('End of Life Notice', 'genericobject') }}</h5>
-                    <p class="mb-0">
-                        {{ __('GenericObject v3.0.0 is an End-of-Life version. All custom asset creation functionality has been moved to GLPI 11 native asset definition.', 'genericobject') }}
-                    </p>
-                </div>
-            </div>
-        </div>
+        {# EOL Warning Alert #}
+        {{ alerts.alert_warning(
+            __('End of Life Notice', 'genericobject'),
+            [__('GenericObject v3.0.0 is an End-of-Life version. All custom asset creation functionality has been moved to GLPI 11 native asset definition.', 'genericobject')]
+        ) }}
 
-        {# Rename Info Banner #}
-        <div class="alert alert-primary border-start border-primary border-2 mb-4">
-            <div class="d-flex align-items-start">
-                <i class="ti ti-pencil text-primary me-3 mt-1 fa-lg"></i>
-                <div>
-                    <h5 class="alert-heading mb-2">{{ __('Name Conflict?', 'genericobject') }}</h5>
-                    <p class="mb-0">
-                        {{ __('If a GenericObject type shares the same name as a native GLPI asset (e.g. Printer, Computer), migration will fail. Use the Rename button on the relevant card below to resolve the conflict before migrating.', 'genericobject') }}
-                    </p>
-                </div>
-            </div>
-        </div>
+        {# Rename Info Alert #}
+        {{ alerts.alert_info(
+            __('Name Conflict?', 'genericobject'),
+            [__('If a GenericObject type shares the same name as a native GLPI asset (e.g. Printer, Computer), migration will fail. Use the Rename button on the relevant card below to resolve the conflict before migrating.', 'genericobject')]
+        ) }}
 
-        {# Name Too Long Banner — only shown when types exceed the max name length #}
+        {# Name Too Long Alert — only shown when types exceed the max name length #}
         {% if too_long_count > 0 %}
-            <div class="alert alert-danger border-start border-danger border-2 mb-4">
-                <div class="d-flex align-items-start">
-                    <i class="ti ti-alert-circle text-danger me-3 mt-1 fa-lg"></i>
-                    <div>
-                        <h5 class="alert-heading mb-2">
-                            {{ __('Name too long', 'genericobject') }}
-                            <span class="badge bg-danger ms-2">{{ too_long_count }}</span>
-                        </h5>
-                        <p class="mb-0">
-                            {% if too_long_count == 1 %}
-                                {{ __('1 type has a name that exceeds the maximum allowed length of %d characters. Please rename it manually before migrating.', 'genericobject')|format(constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH')) }}
-                            {% else %}
-                                {{ (too_long_count ~ ' ' ~ __('types have names that exceed the maximum allowed length of %d characters and cannot be automatically renamed. Please rename them manually before migrating.', 'genericobject'))|format(constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH')) }}
-                            {% endif %}
-                        </p>
-                    </div>
-                </div>
-            </div>
+            {% set too_long_message = (too_long_count ~ ' ' ~ __('type(s) have names that exceed the maximum allowed length of %d characters and cannot be automatically renamed. Please rename them manually before migrating.', 'genericobject'))|format(constant('PluginGenericobjectType::MAX_TYPE_NAME_LENGTH')) %}
+            {{ alerts.alert_danger(
+                __('Name too long', 'genericobject') ~ ' (' ~ too_long_count ~ ')',
+                [too_long_message]
+            ) }}
         {% endif %}
 
-        {# Name Conflict Banner — only shown when conflicts exist #}
+        {# Name Conflict Alert — only shown when conflicts exist #}
         {% if conflict_count > 0 %}
-            <div class="alert alert-danger border-start border-danger border-2 mb-4">
-                <div class="d-flex align-items-start">
-                    <i class="ti ti-alert-circle text-danger me-3 mt-1 fa-lg"></i>
-                    <div>
-                        <h5 class="alert-heading mb-2">
-                            {{ __('Name Conflict detected', 'genericobject') }}
-                            <span class="badge bg-danger ms-2">{{ conflict_count }}</span>
-                        </h5>
-                        <p class="mb-0">
-                            {% if conflict_count == 1 %}
-                                {{ __('1 type cannot be migrated because its name is reserved by a native GLPI asset. Use the Rename button on the card below to fix it before migrating.', 'genericobject') }}
-                            {% else %}
-                                {{ conflict_count ~ ' ' ~ __('types cannot be migrated because their names are reserved by native GLPI assets. Use the Rename button on the cards below to fix them before migrating.', 'genericobject') }}
-                            {% endif %}
-                        </p>
-                    </div>
-                </div>
-            </div>
+            {% set conflict_message = conflict_count ~ ' ' ~ __('type(s) cannot be migrated because their names are reserved by native GLPI assets. Use the Rename button on the cards below to fix them before migrating.', 'genericobject') %}
+            {{ alerts.alert_danger(
+                __('Name Conflict detected', 'genericobject') ~ ' (' ~ conflict_count ~ ')',
+                [conflict_message]
+            ) }}
         {% endif %}
 
         {# Migration Status Card #}

--- a/templates/migration_status.html.twig
+++ b/templates/migration_status.html.twig
@@ -431,7 +431,14 @@
     }
 </style>
 <script>
+    const glpiGenericobjectDebounceTimers = new WeakMap();
+
     function glpiGenericobjectUpdateCounter(input) {
+        clearTimeout(glpiGenericobjectDebounceTimers.get(input));
+        glpiGenericobjectDebounceTimers.set(input, setTimeout(() => glpiGenericobjectFetchSystemName(input), 300));
+    }
+
+    function glpiGenericobjectFetchSystemName(input) {
         const maxLen = parseInt(input.getAttribute('maxlength'));
         const counterId = input.dataset.counterTarget;
         const warningId = input.dataset.warningTarget;


### PR DESCRIPTION
- Replace : https://github.com/pluginsGLPI/genericobject/pull/472

---

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42658
- It is not possible to migrate an asset from the genericobject plugin if its name is similar to an asset in the GLPI core. This fix allows users to rename an asset so they can continue the migration.

## Screenshots (if appropriate):
Conflict:
<img width="1430" height="575" alt="image" src="https://github.com/user-attachments/assets/f03ada33-9693-41f0-94d6-1b25aa350cbb" />

Migrate
<img width="1418" height="455" alt="image" src="https://github.com/user-attachments/assets/4f000062-f127-4639-a574-cc79593d51a4" />



